### PR TITLE
Add support for git urls

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,9 @@ gulp.task('lint', function () {
   return gulp.src(paths.lint)
     .pipe(plugins.jshint('.jshintrc'))
     .pipe(plugins.plumber())
-    .pipe(plugins.jscs())
+    .pipe(plugins.jscs({
+      configPath: './.jscs.json'
+    }))
     .pipe(plugins.jshint.reporter('jshint-stylish'));
 });
 

--- a/index.js
+++ b/index.js
@@ -11,8 +11,9 @@
 var url = require('url');
 var util = require('util');
 var duoParse = require('duo-parse');
+var giturl = require('giturl');
 
-var isLocalPath = function(val) {
+function isLocalPath(val) {
   if (val === '..') {
     return true;
   }
@@ -23,7 +24,18 @@ var isLocalPath = function(val) {
   }
 
   return false;
-};
+}
+
+function isGitUrl(url) {
+  return url && url.indexOf('git') === 0;
+}
+
+function removeCommitIsh(url) {
+  if (url.indexOf('.git#') === -1) {
+    return url;
+  }
+  return url.split('.git#')[0] + '.git';
+}
 
 function removeTrailingSlash(value) {
   if (value.slice(-1) === '/') {
@@ -43,6 +55,10 @@ module.exports = function(dep, href) {
 
     // resolve local path like ../folder/file.js
     result = url.resolve(href, dep);
+
+  } else if (isGitUrl(dep)) {
+
+    result = giturl.parse(removeCommitIsh(dep));
 
   } else if (gh.user && gh.repo) {
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "keywords": [],
   "dependencies": {
-    "duo-parse": "^0.1.1"
+    "duo-parse": "^0.1.1",
+    "giturl": "0.0.3"
   },
   "devDependencies": {
     "gulp": "^3.8.8",

--- a/test/github-linker-resolve_test.js
+++ b/test/github-linker-resolve_test.js
@@ -100,6 +100,30 @@ describe('resolve', function () {
     });
   });
 
+  // git urls can have diffrent forms see https://www.npmjs.org/doc/files/package.json.html#git-urls-as-dependencies
+  describe('git urls', function () {
+
+    it('git://github.com/user/project.git#commit-ish', function() {
+      resolve('git://github.com/user/project.git#commit-ish').should.equal('https://github.com/user/project');
+    });
+
+    it('git+ssh://user@hostname:project.git#commit-ish', function() {
+      resolve('git+ssh://user@hostn://hostname/project');
+    });
+
+    it('git+ssh://user@hostname/project.git#commit-ish', function() {
+      resolve('git+ssh://user@hostname/project.git#commit-ish').should.equal('http://hostname/project');
+    });
+
+    it('git+http://user@hostname/project/blah.git#commit-ish', function() {
+      resolve('git+http://user@hostname/project/blah.git#commit-ish').should.equal('http://hostname/project/blah');
+    });
+
+    it('git+https://user@hostname/project/blah.git#commit-ish', function() {
+      resolve('git+https://user@hostname/project/blah.git#commit-ish').should.equal('http://hostname/project/blah');
+    });
+  });
+
   describe('shorthand duojs', function () {
 
     it('user/repo@master', function () {


### PR DESCRIPTION
Add support for git urls.
Now following git url formats are supported: ([source](https://www.npmjs.org/doc/files/package.json.html#git-urls-as-dependencies))

```
git://github.com/user/project.git#commit-ish
git+ssh://user@hostname:project.git#commit-ish
git+ssh://user@hostname/project.git#commit-ish
git+http://user@hostname/project/blah.git#commit-ish
git+https://user@hostname/project/blah.git#commit-ish
```
